### PR TITLE
Add DOCTYPE to match W3C basic HTML document

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -30,6 +30,7 @@ const themeMetadatas = themeFolders.map(theme =>{
 })
 
 const head = `
+<!DOCTYPE html>
 <html>
 <head>
   <title>VS Code themes</title>


### PR DESCRIPTION
Add `<!DOCTYPE html>` to match W3C basic HTML document.